### PR TITLE
Update container path

### DIFF
--- a/.github/workflows/build-static-html.yml
+++ b/.github/workflows/build-static-html.yml
@@ -18,7 +18,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Build sphinx html output
-        run: sphinx-build -b html src/ build/v1/docs/
+        run: sphinx-build -b html src/ build/
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM httpd:2.4-alpine
-COPY ./build/ /usr/local/apache2/htdocs/
+COPY ./build/ /usr/local/apache2/htdocs/v1/docs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON=python3
 VENV=.venv
+CONTAINERNAME=dataset-api-docs
 
 .DEFAULT_GOAL:=help
 
@@ -9,8 +10,8 @@ python-venv:  ## Create python venv and install requirements
 	. ${VENV}/bin/activate; \
 	pip install -r requirements.txt
 
-.PHONY: api-docs
-api-docs:  ## Build api documentation
+.PHONY: build
+build:  ## Build api documentation
 	. ${VENV}/bin/activate; \
 	sphinx-build -b html src/ build/
 
@@ -18,6 +19,14 @@ api-docs:  ## Build api documentation
 auto-reload-server:  ## Start sphinx autobild server
 	. ${VENV}/bin/activate; \
 	sphinx-autobuild -b html --host localhost src/ build
+
+.PHONY: container-image
+container-image: build  ## Build a docker image with the docs.
+	docker build . -t ${CONTAINERNAME}
+
+.PHONY: run-container
+run-container: container-image  ## Run a container with the docs.
+	docker run -p 8000:80 ${CONTAINERNAME}
 
 .PHONY: clean
 clean:  ## Remove the build files

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a python environment
 
 Build the docs
 
-    make api-docs
+    make build
 
 If you want to start a server which builds and reloads the docs automatically upon 
 changes in the source files run

--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ changes in the source files run
     make auto-reload-server
 
 The documentation will be available at http://localhost:8000
+
+### Containerized Build
+
+You can build a container image with the documentation via
+
+    make container-image
+
+and run the image with
+
+    make run-container
+
+The containerized documentation is available at http://localhost:8000/v1/docs


### PR DESCRIPTION
## Description

The documentation is located in different path when building a locally compared to when building via action. This PR fixes this. The documentation path is in both cases `<web root>/v1/docs`.

I also added make commands for building and running the container image.